### PR TITLE
"perseConfig" doesn't use "cfgFile" parameter.

### DIFF
--- a/src/Bootstrap.hs
+++ b/src/Bootstrap.hs
@@ -1,5 +1,5 @@
 import Web.Blog
 
 main =
-    do cfg <- parseConfig "blog.ini"
+    do cfg <- parseConfig "blog.cfg"
        runBlog cfg

--- a/src/Web/Blog.hs
+++ b/src/Web/Blog.hs
@@ -32,7 +32,7 @@ data BlogCfg
 
 parseConfig :: FilePath -> IO BlogCfg
 parseConfig cfgFile =
-    do cfg <- C.load [C.Required "blog.cfg"]
+    do cfg <- C.load [C.Required cfgFile]
        db <- C.require cfg "db"
        port <- C.require cfg "port"
        name <- C.require cfg "blogName"


### PR DESCRIPTION
I found the unused parameter. Is this patch correct?
