### PR TITLE
Bumped digestive bootstrap version

### DIFF
--- a/src/Web/Forms/Login.hs
+++ b/src/Web/Forms/Login.hs
@@ -24,9 +24,16 @@ loginFormSpec =
     FormMeta
     { fm_method = POST
     , fm_target = "/login"
-    , fm_elements =
-        [ FormElement "name" (Just "Username") InputText
-        , FormElement "password" (Just "Password") InputPassword
+    , fm_components =
+        [ FCSection
+            FormSection
+            { fs_title = Nothing
+            , fs_help = Nothing
+            , fs_elements =
+                [ FormElement "name" (Just "Username") (Just "Username") InputText
+                , FormElement "password" (Just "Password") (Just "Password") InputPassword
+                ]
+            }
         ]
-    , fm_submitText = "Login"
+    , fm_submitValue = "Login"
     }

--- a/src/Web/Forms/Post.hs
+++ b/src/Web/Forms/Post.hs
@@ -19,10 +19,17 @@ postFormSpec =
     FormMeta
     { fm_method = POST
     , fm_target = "/write"
-    , fm_elements =
-        [ FormElement "title" (Just "Title") InputText
-        , FormElement "date" (Just "Date") InputText
-        , FormElement "content" (Just "Content") $ InputTextArea (Just 30) (Just 10)
+    , fm_components =
+        [ FCSection
+            FormSection
+            { fs_title = Nothing
+            , fs_help = Nothing
+            , fs_elements =
+                [ FormElement "title" (Just "Title") (Just "Title") InputText
+                , FormElement "date" (Just "Date") Nothing InputText
+                , FormElement "content" (Just "Content") (Just "Content") $ InputTextArea (Just 30) (Just 10)
+                ]
+            }
         ]
-    , fm_submitText = "Publish"
+    , fm_submitValue = "Publish"
     }

--- a/src/Web/Forms/Register.hs
+++ b/src/Web/Forms/Register.hs
@@ -28,11 +28,18 @@ registerFormSpec =
     FormMeta
     { fm_method = POST
     , fm_target = "/register"
-    , fm_elements =
-        [ FormElement "name" (Just "Username") InputText
-        , FormElement "email" (Just "Email") InputText
-        , FormElement "password1" (Just "Password") InputPassword
-        , FormElement "password2" (Just "Repeat Password") InputPassword
+    , fm_components =
+        [ FCSection
+            FormSection
+            { fs_title = Nothing
+            , fs_help = Nothing
+            , fs_elements =
+                [ FormElement "name" (Just "Username") (Just "Username") InputText
+                , FormElement "email" (Just "Email") (Just "Email") InputText
+                , FormElement "password1" (Just "Password") (Just "Password") InputPassword
+                , FormElement "password2" (Just "Repeat Password") (Just "Repeat Password") InputPassword
+                ]
+            }
         ]
-    , fm_submitText = "Register"
+    , fm_submitValue = "Register"
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,6 @@ packages:
     extra-dep: true
 extra-deps:
   - digestive-functors-0.8.2.0
-  - digestive-bootstrap-0.1.0.1
+  - digestive-bootstrap-0.3.0.0
   - digestive-functors-blaze-0.6.1.0
 resolver: lts-8.12


### PR DESCRIPTION
Project now uses digestive-bootstrap-0.3.0.0. Updated the Login,
Register, and Post forms as appropriate to match the new API.

@agrafix  I could not easily find an example online of a project using the new API for digestive bootstrap added in version 0.3.0.0 so I updated "funblog" to use it. I have done some quick testing between this commit and master and the form behavior appears the same between the two commits.